### PR TITLE
GUI help tab and progress indicator

### DIFF
--- a/bin/setup_pyinstaller.spec
+++ b/bin/setup_pyinstaller.spec
@@ -78,6 +78,8 @@ a = Analysis(
 		(path_qt5.resolve(), pathlib.Path("Pyqt5") / "Qt5"),
 		# extractor specs
 		("../extractors", "extractors"),
+		# documentation
+		("../docs", "docs"),
 	],
 	hiddenimports=[],
 	hookspath=[],

--- a/citov/extractor.py
+++ b/citov/extractor.py
@@ -46,8 +46,10 @@ class DbExtractor(overlapper.DbMatcher):
 			for overlaps; defaults to None.
 
 	"""
-	#: str: Default overlaps file output filename.
-	DEFAULT_OVERLAPS_PATH = 'citation_combo'
+	#: Default overlaps file output filename.
+	DEFAULT_OVERLAPS_PATH: str = 'overlapped'
+	#: Default folder name for cleaned citation lists.
+	DEFAULT_CLEANED_DIR_PATH: str = 'cleaned'
 
 	_YAML_MATCHER = {
 		'ExtractKeys': ExtractKeys,
@@ -363,25 +365,26 @@ class DbExtractor(overlapper.DbMatcher):
 		return df
 
 	def exportDataFrames(self, overlapsOutPath: str) -> List[str]:
-		"""Export parsed database and overlaps data frames to directory.
+		"""Export parsed database and overlaps data frames to a directory.
 
 		Args:
-			overlapsOutPath: Path to export directory, which will be created
-				if it non-existant.
+			overlapsOutPath: Path to export file. Parents directories which
+				will be created if necessary.
 
 		Returns:
 			List of output messages.
 
 		"""
-		os.makedirs(overlapsOutPath, exist_ok=True)
+		outDirCleaned = os.path.join(
+			os.path.dirname(overlapsOutPath), self.DEFAULT_CLEANED_DIR_PATH)
+		os.makedirs(outDirCleaned, exist_ok=True)
 		msgs = []
 		for dbName, df in self.dfsParsed.items():
 			msgs.append(self._saveDataFrame(
-				df, os.path.join(overlapsOutPath, dbName), '_clean')[0])
+				df, os.path.join(outDirCleaned, dbName), '_clean')[0])
 		if self.dfOverlaps is not None:
 			msgs.append(self._saveDataFrame(
-				self.dfOverlaps,
-				os.path.join(overlapsOutPath, 'combined'))[0])
+				self.dfOverlaps, overlapsOutPath)[0])
 		return msgs
 
 

--- a/citov/extractor.py
+++ b/citov/extractor.py
@@ -7,6 +7,8 @@ import glob
 import logging
 import os
 import pathlib
+from typing import List
+
 import sys
 
 import pandas as pd
@@ -360,24 +362,26 @@ class DbExtractor(overlapper.DbMatcher):
 		self.dfOverlaps = df
 		return df
 
-	def exportDataFrames(self, overlapsOutPath):
-		"""Export parsed database and overlaps data frames to file.
+	def exportDataFrames(self, overlapsOutPath: str) -> List[str]:
+		"""Export parsed database and overlaps data frames to directory.
 
 		Args:
-			overlapsOutPath (str): Path to overlaps files.
+			overlapsOutPath: Path to export directory, which will be created
+				if it non-existant.
 
 		Returns:
-			List[str]: List of output messages.
+			List of output messages.
 
 		"""
-		dirPath = os.path.dirname(overlapsOutPath)
+		os.makedirs(overlapsOutPath, exist_ok=True)
 		msgs = []
 		for dbName, df in self.dfsParsed.items():
 			msgs.append(self._saveDataFrame(
-				df, os.path.join(dirPath, dbName), '_clean')[0])
+				df, os.path.join(overlapsOutPath, dbName), '_clean')[0])
 		if self.dfOverlaps is not None:
 			msgs.append(self._saveDataFrame(
-				self.dfOverlaps, overlapsOutPath)[0])
+				self.dfOverlaps,
+				os.path.join(overlapsOutPath, 'combined'))[0])
 		return msgs
 
 

--- a/citov/extractor.py
+++ b/citov/extractor.py
@@ -323,6 +323,21 @@ class DbExtractor(overlapper.DbMatcher):
 			raise FileNotFoundError(f'Could not find extrator for "{path}"')
 		return df_out, dbName
 
+	@staticmethod
+	def checkExtraction(df: pd.DataFrame):
+		"""Check the database extraction result.
+		
+		Args:
+			df: Extracted database as a data frame.
+
+		Raises:
+			`SyntaxWarning`: warning if no author names were detected.
+
+		"""
+		# TODO: check additional fields?
+		if all(df['Author_Names'] == '.'):
+			raise SyntaxWarning('No author names detected')
+
 	def combineOverlaps(self, fn_prog: Optional[Callable[[int, str], None]] = None):
 		"""Combine overlaps from extracted databases in :attr:`dbParsed`.
 

--- a/citov/gui.py
+++ b/citov/gui.py
@@ -134,12 +134,17 @@ class CiteOverlapHandler(Handler):
 		table_widgets = info.ui.control.findChildren(QtWidgets.QTableView)
 		for table in table_widgets:
 			table.horizontalHeader().setDefaultAlignment(QtCore.Qt.AlignLeft)
-
-		for i, view in enumerate(info.object.importViews):
+		
+		views = list(info.object.importViews)
+		views.append(None)
+		for i, view in enumerate(views):
 			# rename tabs in all tabbed panes since the CiteImport triggered
-			# names appear to be overridden
+			# names appear to be overridden, with one extra iteration to
+			# change the last ("Overlaps") tab in the largest Tabbed group
 			info.object.renameSheetTab = i
-			info.object.renameSheetName = _displayExtractor(view.extractor)
+			# any string to trigger change if view is None
+			info.object.renameSheetName = (
+				'change' if view is None else _displayExtractor(view.extractor))
 			self.object_renameSheetName_changed(info)
 		
 		# trigger renaming the overlaps tab in the largest tabbed pane

--- a/citov/gui.py
+++ b/citov/gui.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from enum import Enum, auto
 import glob
 import os
+import sys
 
 import numpy as np
 from PyQt5 import QtWidgets, QtCore
@@ -305,13 +306,16 @@ class CiteOverlapGUI(HasTraits):
 	
 	# HELP PANEL TRAITS
 	
-	_helpHtml = HTML(
-		f'<p>Thanks for using Citation-Overlap!</p>'
-		f'<p>For help and more resources, please visit:</p>'
-		f'<p><ul>'
-		f'<li><a href="https://github.com/stephansanders/citation-overlap">'
-		f'Software homepage and instruction</li>'
-		f'</ul></p>')
+	pkgDir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+	docsDir = os.path.join(pkgDir, "docs")
+	if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+		# detect frozen env using the PyInstaller-specific attributes
+		# (currently works even without this setting through symlinks)
+		docsDir = os.path.realpath(os.path.join(sys._MEIPASS, "docs"))
+	with open(os.path.join(docsDir, "sidebar.html"), mode="r") as help_file:
+		helpMsg = "".join(help_file.readlines())
+	
+	_helpHtml = HTML(helpMsg)
 	
 	# SHEETS TRAITS
 	

--- a/citov/gui.py
+++ b/citov/gui.py
@@ -767,18 +767,17 @@ class CiteOverlapGUI(HasTraits):
 
 	@on_trait_change('_exportBtn')
 	def exportTables(self):
-		"""Export tables to a folder."""
+		"""Export tables to a files."""
 		self.dbExtractor.saveSep = self._EXPORT_SEPS[self._exportSep]
 		try:
-			# prompt user to select a folder output path and save each filtered,
-			# cleaned citation list along with the combined, overlapped list;
-			# TODO: file dialog does not allow selecting an existing directory
-			# WORKAROUND: select parent dir and type in the existing dir
+			# prompt user to select an output file path for the combined list;
+			# save along with filtered folders in a separate dir there
 			save_path = self._getFileDialogPath(
 				self.dbExtractor.DEFAULT_OVERLAPS_PATH, "save as")
 			self.dbExtractor.exportDataFrames(save_path)
 			self._statusBarMsg = (
-				f'Saved filtered tables and combined table to: {save_path}')
+				f'Saved combined table to "{save_path}" and filtered tables '
+				f'alongside in "{self.dbExtractor.DEFAULT_CLEANED_DIR_PATH}"')
 		except FileNotFoundError:
 			print("Skipping file save")
 

--- a/citov/gui.py
+++ b/citov/gui.py
@@ -767,15 +767,18 @@ class CiteOverlapGUI(HasTraits):
 
 	@on_trait_change('_exportBtn')
 	def exportTables(self):
-		"""Export tables to file."""
+		"""Export tables to a folder."""
 		self.dbExtractor.saveSep = self._EXPORT_SEPS[self._exportSep]
 		try:
+			# prompt user to select a folder output path and save each filtered,
+			# cleaned citation list along with the combined, overlapped list;
+			# TODO: file dialog does not allow selecting an existing directory
+			# WORKAROUND: select parent dir and type in the existing dir
 			save_path = self._getFileDialogPath(
 				self.dbExtractor.DEFAULT_OVERLAPS_PATH, "save as")
 			self.dbExtractor.exportDataFrames(save_path)
 			self._statusBarMsg = (
-				f'Saved "{os.path.basename(save_path)}" and filtered tables to:'
-				f' {os.path.dirname(save_path)}')
+				f'Saved filtered tables and combined table to: {save_path}')
 		except FileNotFoundError:
 			print("Skipping file save")
 

--- a/citov/gui.py
+++ b/citov/gui.py
@@ -161,9 +161,10 @@ class CiteOverlapHandler(Handler):
 		
 		for ed in info.ui._editors:
 			if ed.name == "_helpHtml":
-				# enable opening links in an external browser in help doc
-				# editor, assumed to be a QTextBrowser
-				ed.control.setOpenExternalLinks(True)
+				if hasattr(ed.control, "setOpenExternalLinks"):
+					# enable opening links in an external browser in help doc
+					# editor, a QTextBrowser if QtWebEngine is not available
+					ed.control.setOpenExternalLinks(True)
 	
 	@staticmethod
 	def getSheetsTabWidget(info):

--- a/citov/gui.py
+++ b/citov/gui.py
@@ -150,6 +150,12 @@ class CiteOverlapHandler(Handler):
 		# trigger renaming the overlaps tab in the largest tabbed pane
 		info.object.renameSheetTab = len(info.object.importViews)
 		info.object.renameSheetName = ''
+		
+		for ed in info.ui._editors:
+			if ed.name == "_helpHtml":
+				# enable opening links in an external browser in help doc
+				# editor, assumed to be a QTextBrowser
+				ed.control.setOpenExternalLinks(True)
 	
 	@staticmethod
 	def getSheetsTabWidget(info):

--- a/citov/overlaps_thread.py
+++ b/citov/overlaps_thread.py
@@ -1,0 +1,48 @@
+# PyQt5 thread for running overlaps detection
+
+from typing import TYPE_CHECKING, Callable
+
+from PyQt5 import QtCore
+
+if TYPE_CHECKING:
+	from citov import extractor
+
+
+class OverlapsThread(QtCore.QThread):
+	"""Thread for setting up file import by extracting image metadata.
+
+	Attributes:
+		dbExtractor: Database extractor.
+		fn_success: Function after finding overlaps.
+		fn_prog: Function to update progress of finding overlaps.
+
+	"""
+
+	signal = QtCore.pyqtSignal(object)
+	signal_prog = QtCore.pyqtSignal(object, object)
+
+	def __init__(
+			self, dbExtractor: "extractor.DbExtractor", fn_success,
+			fn_prog: Callable[[int, str], None]):
+		"""Initialize the overlap detection thread."""
+		super().__init__()
+		self.dbExtractor = dbExtractor
+		self.signal.connect(fn_success)
+		self.signal_prog.connect(fn_prog)
+
+	def run(self):
+		"""Find overlaps."""
+		try:
+			# find overlaps with progress tracking
+			result = self.dbExtractor.combineOverlaps(
+				lambda x, y: self.signal_prog.emit(x, y))
+			
+		except TypeError as e:
+			# TODO: catch additional errors that may occur with overlaps
+			result = \
+				'An erorr occurred while finding overlaps across databases.' \
+				' Please try again, or check the logs for more details.'
+			print(result)
+			print(e)
+		self.signal.emit(result)
+

--- a/docs/sidebar.html
+++ b/docs/sidebar.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Citation-Overlap Quick Start</title>
+</head>
+<body>
+<h1>Quick Start</h1>
+
+<p>Thanks for using Citation-Overlap!</p>
+
+<p>Citation-Overlap is a tool to identify similar or duplicate citations from multiple bibliographic database searches. It imports lists from MEDLINE, Embase, and other databases, integrates them into a common format, and measures citation similarity to output a combined list showing duplicates with similarity scores. This tool facilitates deduplication for systematic reviews, meta-analyses, and other comprehensive literature searches.</p>
+
+<p>For help and more resources, please visit:<br/>
+<a href="https://github.com/stephansanders/citation-overlap">https://github.com/stephansanders/citation-overlap</a>
+</p>
+
+<h2>Load Citation Files</h2>
+
+<p>First, select the citation list's database source from the dropdown box. Click the folder icon to browse to your citation file. The list will be entered into a sheet named by the database.</p>
+
+<p>For each additional citation file, add it to the next citation group as before.</p>
+
+<p>If you have more citation files, click the "Add Sheet" button to open a new citation group. Up to 7 citation lists can be added (unlimited in the command-line tool).</p>
+
+<h2>Find Overlaps</h2>
+
+<p>To find citation overlaps across your lists, click the "Find Overlaps" button. It performs deduplication by finding similarities among citations and groups potential duplicates.</p>
+
+<p>This step may take a few minutes to complete. As lists are filtered, they will be inserted as new sheets, followed by the "overlaps" sheet when deduplication is complete.</p>
+
+<h2>(Optional) Add an Extractor for a New Database Source</h2>
+
+<p>If you have a citation list from a database not currently listed in the dropdown boxes, you can add your own extractor for the database. See the <a href="https://github.com/stephansanders/citation-overlap/tree/master/extractors">extractors folder</a> for examples of definition files for reading citation lists from various databases.</p>
+
+<p>Once you've designed your own extractor, click on the "Add Extractor" button to browse to your custom extractor. It will appear in as a choice in all the dropdown boxes.</p>
+</body>
+</html>

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,8 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - traitsui
+  - traitsui>=7.2.0
   - pyqt
-  - PyQtWebEngine
   - jellyfish
   - pandas
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.6
   - traitsui
   - pyqt
+  - PyQtWebEngine
   - jellyfish
   - pandas
   - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ config = {
 	"python_requires": ">=3.6",
 	"install_requires": [
 		"PyQt5",
-		"PyQtWebEngine",
-		"traitsui",
+		"traitsui >= 7.2.0",
 		"jellyfish",
 		"pandas",
 		"pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ config = {
 	"python_requires": ">=3.6",
 	"install_requires": [
 		"PyQt5",
+		"PyQtWebEngine",
 		"traitsui",
 		"jellyfish",
 		"pandas",


### PR DESCRIPTION
This PR is a roundup of GUI enhancement and fixes to streamline usage of the graphical user interface.

- Fixes #13: The controls sidebar has been moved into a tabbed pane, which gives extra margins to the sidebar.
- Fixes #14: The sidebar tabbed pane now includes a "Help" tab with a quick start guide. At the top of the instructions is a link to the repository website, which will host additional documentation. This change requires [TraitsUI v7.2.0](https://github.com/enthought/traitsui/releases/tag/7.2.0) to open links without `QtWebEngine`.
- Fixes #17: After extracting a citation list, the `Author_Names` column is checked for extracted author lists. If none are found, a warning is displayed in the status bar. The extracted contents are still displayed in the table to assist with troubleshooting the extraction.
- Fixes #18: The `_cleaned` versions of the citation lists are output to a `cleaned` next to the overlaps file to avoid confusing them with the original files.
- Fixes #19: The find overlaps task has been moved into a separate thread to keep the GUI responsive during processing. A progress bar has been added underneath the "Find Overlaps" button to track overlap detection for each citation list.
- Also includes a fix to the name of the "Overlaps" sheet tab after adding the max number of tabs.